### PR TITLE
Fix OS name typo in plugins

### DIFF
--- a/plugins/debian_9_x64
+++ b/plugins/debian_9_x64
@@ -1,4 +1,4 @@
-#OS Debian_8_x64
+#OS Debian_9_x64
 #COMMENTS Debian comments
 #M update:upgrade:apt-get update && apt-get upgrade
 #M mysql:MySQL:_install mariadb-server mariadb mariadb-client

--- a/plugins/ubuntu_16_x64
+++ b/plugins/ubuntu_16_x64
@@ -1,4 +1,4 @@
-#OS Ubuntu 14_x64
+#OS Ubuntu 16_x64
 #COMMENTS Ubuntu comments
 #M update:upgrade:apt-get update
 #M mysql:MySQL:_install mysql-server

--- a/plugins/ubuntu_18_x64
+++ b/plugins/ubuntu_18_x64
@@ -1,4 +1,4 @@
-#OS Ubuntu 14_x64
+#OS Ubuntu 18_x64
 #COMMENTS Ubuntu comments
 #M update:upgrade:apt-get update
 #M mysql:MySQL:_install mysql-server

--- a/plugins/ubuntu_19_x64
+++ b/plugins/ubuntu_19_x64
@@ -1,4 +1,4 @@
-#OS Ubuntu 14_x64
+#OS Ubuntu 19_x64
 #COMMENTS Ubuntu comments
 #M update:upgrade:apt-get update
 #M mysql:MySQL:_install mysql-server


### PR DESCRIPTION
Updated plugins: debian_9_x64, ubuntu_16_x64, ubuntu_18_x64, ubuntu_19_x64