### PR TITLE
fix: radiusd was unable to autostart

### DIFF
--- a/plugins/ubuntu_16_x64
+++ b/plugins/ubuntu_16_x64
@@ -162,7 +162,7 @@ _install_freeradius() {
 #   description: radiusd is service access provider Daemon.
 ### BEGIN INIT INFO
 # Provides: radiusd
-# Should-Start: radiusd
+# Should-Start: mysql radiusd
 # Should-Stop: radiusd
 # Short-Description: start and stop radiusd
 # Description: radiusd is access provider service Daemon.
@@ -218,7 +218,7 @@ fi
 
 chown ${RADIUS_USER}:${RADIUS_USER} $logdir/radius.log
 chown -R ${RADIUS_USER}:${RADIUS_USER} /usr/local/freeradius/etc/raddb
-chown -R ${RADIUS_USER}:${RADIUS_USER} ${rundir}
+chown -R ${RADIUS_USER}:${RADIUS_USER} ${rundir}/..
 chmod 660 $logdir/radius.log
 
 case "$1" in


### PR DESCRIPTION
Due to access permissions radiusd was unable to create PID file.
Also radiusd was unable to start if it attempt to start earlier than mysql.