### PR TITLE
AInstall: freebsd_11_x64 plugin: replaced 'vim-lite' with 'vim-console' 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1388,7 +1388,7 @@ chown -R ${RADIUS_SERVER_USER}:${RADIUS_SERVER_USER} /usr/local/freeradius/etc/r
 #**********************************************************
 # Build freebsd programs
 #**********************************************************
-freebsd_build2 () {
+freebsd_build2 () { #XXX is not used anywhere
 echo -e '\a \a \a';
 
 FILE_PING='/sbin/ping';

--- a/plugins/freebsd_11_x64
+++ b/plugins/freebsd_11_x64
@@ -13,7 +13,7 @@
 #M fsbackup:FSBackup:_install_fsbackup
 #M build_kernel:Build_Kernel:freebsd_build_kernel
 # perl_speedy 
-#M utils:Utils:_install vim-lite tmux bash git sudo
+#M utils:Utils:_install vim-console tmux bash git sudo
 
 # Variable
 


### PR DESCRIPTION
because it was renamed in freebsd repos. (github issue #101)